### PR TITLE
Playground-Demo-Fix: Subscript and Supscript toolbar buttons were mixed up

### DIFF
--- a/src/components/plate-ui/more-dropdown-menu.tsx
+++ b/src/components/plate-ui/more-dropdown-menu.tsx
@@ -33,8 +33,8 @@ export function MoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              key: MARK_SUBSCRIPT,
-              clear: MARK_SUPERSCRIPT,
+              key: MARK_SUPERSCRIPT,
+              clear: [MARK_SUPERSCRIPT, MARK_SUBSCRIPT],
             });
             focusEditor(editor);
           }}
@@ -46,8 +46,8 @@ export function MoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              key: MARK_SUPERSCRIPT,
-              clear: MARK_SUBSCRIPT,
+              key: MARK_SUBSCRIPT,
+              clear: [MARK_SUPERSCRIPT, MARK_SUBSCRIPT],
             });
             focusEditor(editor);
           }}


### PR DESCRIPTION
Dear maintainers, 

I noticed following bug in the playground demo and provide a small and straight forward fix to it.

The labels were simply mixed up and the clearing behaviour could not handle changing a subscript to a supscript or vice versa.

With best regards,
Leon Müller