### PR TITLE
Fix for type error in draggable.tsx

### DIFF
--- a/src/components/plate-ui/draggable.tsx
+++ b/src/components/plate-ui/draggable.tsx
@@ -125,7 +125,9 @@ export const Draggable = withRef<'div', DraggableProps>(
                 classNames.blockToolbar
               )}
             >
-              <div ref={handleRef} className="size-4">
+              <div ref={(node) => {
+                  handleRef(node);
+                }} className="size-4">
                 {isHovered && dragHandle}
               </div>
             </div>


### PR DESCRIPTION
Fix for below type error

Type 'ConnectDragSource' is not assignable to type 'LegacyRef<HTMLDivElement> | undefined'.
  Type 'ConnectDragSource' is not assignable to type '(instance: HTMLDivElement | null) => void | (() => VoidOrUndefinedOnly)'.